### PR TITLE
Custom Thumbnail

### DIFF
--- a/src/_h5ai/private/php/ext/class-thumb.php
+++ b/src/_h5ai/private/php/ext/class-thumb.php
@@ -29,8 +29,12 @@ class Thumb {
             return null;
         }
 
-        $capture_path = $source_path;
-        if ($type === 'img') {
+        $capture_path = false;
+        $fileparts = pathinfo($source_path);
+        $custom_path = $fileparts['dirname'].'/.thumb/'.$fileparts['filename'].'.jpg';
+        if (file_exists($custom_path)) {
+            $capture_path = $custom_path;
+        } elseif ($type === 'img') {
             $capture_path = $source_path;
         } elseif ($type === 'mov') {
             if ($this->setup->get('HAS_CMD_AVCONV')) {
@@ -46,7 +50,7 @@ class Thumb {
             }
         }
 
-        return $this->thumb_href($capture_path, $width, $height);
+        return $capture_path ? $this->thumb_href($capture_path, $width, $height) : null;
     }
 
     private function thumb_href($source_path, $width, $height) {

--- a/src/_h5ai/public/js/lib/ext/thumbnails.js
+++ b/src/_h5ai/public/js/lib/ext/thumbnails.js
@@ -25,8 +25,6 @@ const queueItem = (queue, item) => {
         type = 'mov';
     } else if (includes(settings.doc, item.type)) {
         type = 'doc';
-    } else {
-        return;
     }
 
     if (item.thumbSquare) {


### PR DESCRIPTION
Add the ability to manually upload a thumbnail for a file. If there is a jpg with the same name in the subdirectory ".thumb", this will be rendered as thumbnail. Good for e.g. video preview, if you don't have ffmpeg, or any other file where creation of thumbnail isn't supported.